### PR TITLE
add check => extract_bits + parse_state_diff word value check + BLOB_…

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -30,6 +30,19 @@ fn main() {
         let original_data = blob::recover(blob_data);
         let state_diffs = serde::parse_state_diffs(original_data.as_slice());
         let state_diffs_json = serde::to_json(state_diffs.as_slice());
-        println!("{}", state_diffs_json);
+        println!("state_diffs_json {}", state_diffs_json);
     }
+}
+
+#[test]
+fn test_cli_sn_goerli() {
+
+    let blob_data = serde::parse_file_to_blob_data( "../../examples/blob/sn_blob_goerli.txt");
+    let original_data = blob::recover(blob_data);
+
+    let state_diffs = serde::parse_state_diffs(original_data.as_slice());
+    let state_diffs_json = serde::to_json(state_diffs.as_slice());
+    println!("{}", state_diffs_json);
+    // TODO assert result of old version of sn_goerli
+
 }

--- a/crates/types/src/serde.rs
+++ b/crates/types/src/serde.rs
@@ -16,7 +16,6 @@ pub fn parse_state_diffs(data: &[BigUint]) -> Vec<ContractUpdate> {
     let mut i = 0;
     let contract_updated_num = data[i].to_usize().unwrap();
     i += 1;
-    println!("contract_updated_num {}", contract_updated_num);
 
     for _ in 0..contract_updated_num {
         let address = data[i].clone();
@@ -119,7 +118,6 @@ pub fn parse_str_to_blob_data(data: &str) -> Vec<BigUint> {
 // Verify bits len and more
 fn extract_bits(word: &BigUint, start: usize, end: usize) -> BigUint {
     let string = format!("{:#b}", word).replace("0b", "");
-    println!("extract_bits word {} start {} and end {}", word, start, end);
     // TODO add check before  call extract_bits?
     if string.len() < end {
         let bit_string: String = format!("{:#b}", word).replace("0b", "");


### PR DESCRIPTION
Example with sn_blob_state_update_da_goerli.txt working now:

cargo run --release -p majin-blob recover --blob-file ./examples/blob/sn_blob_state_update_da_goerli.txt

Done: 

add check around: 
- serde::extract_bits: Check word len before being indexed out of bonds.
- serde::parse_state_diff : add word value check 
- serde::parse_state_diff : BLOB_LEN check 
- serde::parse_state_diff:  key value storage_updates
